### PR TITLE
Aggregate request data

### DIFF
--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -63,6 +63,10 @@ process =
       # Wait for the request to complete then execute middleware
       request.addListener 'end', -> SS.internal.servers[server_name].middleware.execute(request, response)
 
+      # Aggregate request data, forming the request http body
+      request.body = ''
+      request.addListener 'data', (body) -> 
+            request.body += body
 
   # Socket.IO
   socket:


### PR DESCRIPTION
While working with SocketStream http middleware feature, I noticed that I'm not able to access the request data easily, since the middleware callback defined in config/http.coffee gets called on the http request 'end' event and not the 'data' even. 

I've added a small change to lib/server.coffee that saves the request data to a new request property 'body' by listening to the http request 'data' event.

Cheers!
