### PR TITLE
Fixed bug where session.user.loggedIn() was always returning false

### DIFF
--- a/lib/backend/session.coffee
+++ b/lib/backend/session.coffee
@@ -132,7 +132,7 @@ class exports.Session extends EventEmitter
       "#{key}:user:#{@session.user_id}"
     
     loggedIn: ->
-      @session.user_id is not null
+      @session.user_id?
       
     logout: (cb = ->) ->
       SS.users.online.remove(@session.user_id) if SS.config.users.online.enabled


### PR DESCRIPTION
Executing the following code was always passing false to the callback even when @session.user_id was not null. 

```
exports.actions =
  init: (cb) ->
    cb @session.user.loggedIn()
```

I reverted to the code from v0.1.8.
