### PR TITLE
Sending events to a specific browser tab

### DIFF
--- a/lib/backend/responders/server.coffee
+++ b/lib/backend/responders/server.coffee
@@ -13,6 +13,7 @@ prefix = '/app/server'
 var_session = SS.config.reserved_vars.session
 var_request = SS.config.reserved_vars.request
 var_user =    SS.config.reserved_vars.user
+var_socket_id=SS.config.reserved_vars.socket_id
 
 # Make a list of variables you cannot use as action names (and warn below if you try)
 reserved_variables = ['getSession', var_session, var_request, var_user]
@@ -74,6 +75,9 @@ process = (obj, cb) ->
  
   # Create @session object if we have a session_id
   server_module[var_session] = obj.session_obj
+
+  # Add socket_id
+  server_module[var_socket_id] = obj.socket_id
     
   # Keep in for compatibility until 0.3
   server_module.getSession = (scb) ->

--- a/lib/configurator.coffee
+++ b/lib/configurator.coffee
@@ -43,6 +43,7 @@ setDefaults = ->
       request:                'request'
       session:                'session'
       user:                   'user'
+      socket_id:              'socket_id'
 
     # Default settings for /app/server files
     server_files:

--- a/lib/frontend/socket.coffee
+++ b/lib/frontend/socket.coffee
@@ -46,6 +46,7 @@ newConnection = (socket) ->
     preProcess socket, ->
       msg.responder = 'server'
       msg.session = socket.ss.session
+      msg.socket_id = socket.id
       request = rpc.send msg, (response) ->
         updateSessionCache(socket, response)
         cb response


### PR DESCRIPTION
Browser tab is associated with a specific socket. Therefore
to send events directly to a specific tab we need to send them
to a specific socket. It is now possible to do so using:

SS.publish.socket(socket_id, ...)

Within server modules @socket_id variable becomes available too.
