### PR TITLE
Custom http.coffee was not used if it contained module not found errors

### DIFF
--- a/lib/frontend/http_middleware/index.coffee
+++ b/lib/frontend/http_middleware/index.coffee
@@ -5,6 +5,7 @@
 util = require('util')
 connect = require('connect')
 copy = require('../../utils/copy.coffee')
+path = require('path')
 
 #Load middleware stack for the primary HTTP/HTTPS server
 exports.primary = (ssl_options = null) ->
@@ -55,15 +56,11 @@ class Stack
   # Load custom HTTP config file and any custom middleware first
   loadCustom: (server_name) ->
     file = "/config/http.coffee"
+    customPath = "#{SS.root}#{file}"
+    defaultPath = "#{__dirname}/../../../new_project#{file}"
 
     # Look for custom middleware. If it doesn't exist automatically use the default file
-    try
-      custom = require("#{SS.root}#{file}")
-    catch e
-      if e.message.match(/^Cannot find module/)
-        custom = require(__dirname + "/../../../new_project#{file}")
-      else
-        throw e
+    custom = require (if path.existsSync(customPath) then customPath else defaultPath)
 
     if custom[server_name]
       @stack = @stack.concat(custom[server_name])


### PR DESCRIPTION
Since we know the exact file path of `http.coffee` and not only its CommonJS module identifier, there's no need to use `require` module identifier resolution to find whether `http.coffee` exists. The existence is better checked explicitly using `path.existsSync`.

The synchronous version is a good idea because `require` uses synchronous file operations anyway.

Old way of catching exceptions from `require` and identifying the thrown exception by a substring was not robust enough. It failed if `http.coffee` had `require('foo')` and `foo` didn't exist.
