### PR TITLE
Small fix to enable use of "include" in Jade templates

### DIFF
--- a/lib/frontend/asset/compile.coffee
+++ b/lib/frontend/asset/compile.coffee
@@ -53,7 +53,7 @@ exports.compile =
     # Replace the 'SocketStream' magic keyword within the Jade file with all the asset inclusions
     locals = {SocketStream: headersAndTemplates().join('')}
     try
-      parser = jade.compile(input)
+      parser = jade.compile(input, {filename: path})
       html = parser(locals)
       cb {output: html, content_type: 'text/html'}
     catch e


### PR DESCRIPTION
The use of `require` in Jade templates in Socketstream currently results in a pretty explicit error:
   _Unable to compile Jade file ... to HTML: Error: the `filename` option is required to use `include`s_

From Jade documentation:
   `filename` Used in exceptions, and required when using `include`s

If it makes any sense, I would like to propose to add this option in the asset compiler.
