### PR TITLE
Additional small fix to enable use of "include" in Jade Asset Templates

### DIFF
--- a/lib/frontend/asset/templates.coffee
+++ b/lib/frontend/asset/templates.coffee
@@ -27,7 +27,7 @@ compile =
 
   jade: (path, source) ->
     try
-      jade.compile(source)()
+      jade.compile(source, {filename: "#{SS.root}/#{path}"})()
     catch e
       console.error 'Unable to render jade template: ' + path
       throw new Error(e)


### PR DESCRIPTION
Related to Pull request [#96](https://github.com/socketstream/socketstream/issues/96):

`jade.compile` is also called by the asset manager while compiling the _Asset Templates_ (in `app/views` sub-directories), hence we need to add the `filename` option to enable the use of `include`s there too.

Unlike in `compile.coffee` file , the `path` in `templates.coffee` is relative. Therefore we need to contstruct the absolute path this time: `{filename: "#{SS.root}/#{path}"}`.

Thank you,
Jean-Philippe.
