### PR TITLE
Support Windows paths

### DIFF
--- a/lib/socketstream.js
+++ b/lib/socketstream.js
@@ -7,7 +7,7 @@ require('colors');
 var version = exports.version = require('./utils/file').loadPackageJSON().version;
 
 // Set root path of your project
-var root = exports.root = process.cwd();
+var root = exports.root = process.cwd().replace(/\\/g, '/'); // replace '\' with '/' to support Windows
 
 // Warn if attempting to start without a cwd (e.g. through upstart script)
 if (root == '/') throw new Error("You must change into the project directory before starting your SocketStream app")

--- a/lib/utils/file.js
+++ b/lib/utils/file.js
@@ -30,7 +30,7 @@ exports.readDirSync = function(start) {
       var files = fs.readdirSync(start).sort();
       total = files.length;
       for(var x=0, l=files.length; x<l; x++) {
-        isDir(path.join(start, files[x]));
+        isDir(path.join(start, files[x]).replace(/\\/g, '/')); // replace '\' with '/' to support Windows
       }
     } else {
       throw (new Error("path: " + start + " is not a directory"));

--- a/src/socketstream.js
+++ b/src/socketstream.js
@@ -7,7 +7,7 @@ require('colors');
 var version = exports.version = require('./utils/file').loadPackageJSON().version;
 
 // Set root path of your project
-var root = exports.root = process.cwd();
+var root = exports.root = process.cwd().replace(/\\/g, '/'); // replace '\' with '/' to support Windows
 
 // Warn if attempting to start without a cwd (e.g. through upstart script)
 if (root == '/') throw new Error("You must change into the project directory before starting your SocketStream app")

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -30,7 +30,7 @@ exports.readDirSync = function(start) {
       var files = fs.readdirSync(start).sort();
       total = files.length;
       for(var x=0, l=files.length; x<l; x++) {
-        isDir(path.join(start, files[x]));
+        isDir(path.join(start, files[x]).replace(/\\/g, '/')); // replace '\' with '/' to support Windows
       }
     } else {
       throw (new Error("path: " + start + " is not a directory"));


### PR DESCRIPTION
Hi,

I made a small change to make the demo chat project work with Windows-style paths. There is probably a better way to do this, but this small change did the trick on Windows. There would be a regression in *nix if the path contains a '\'-escaped character such as a space, so I suppose the replacement should only occur when running on Windows.

Dave
