### PR TITLE
Support Windows paths

### DIFF
--- a/lib/client_asset_manager/client.js
+++ b/lib/client_asset_manager/client.js
@@ -89,7 +89,7 @@ exports.init = function(root, codeWrappers, templateEngine) {
           var files;
           includes.push(codeForView);
           includes = includes.concat(_this.headers(packAssets));
-          paths.tmpl !== false && (files = magicPath.files(pathlib.join(root, templateDir), paths.tmpl));
+          paths.tmpl !== false && (files = magicPath.files(pathlib.join(root, templateDir).replace(/\\/g, '/'), paths.tmpl)); // replace '\' with '/' to support Windows
           if (files && files.length > 0) {
             return templateEngine.generate(root, templateDir, files, formatters, function(templateHTML) {
               includes.push(templateHTML);
@@ -132,7 +132,7 @@ exports.init = function(root, codeWrappers, templateEngine) {
         };
         if (paths && paths.length > 0) {
           filePaths = [];
-          prefix = pathlib.join(root, dir);
+          prefix = pathlib.join(root, dir).replace(/\\/g, '/'); // replace '\' with '/' to support Windows
           paths.forEach(function(path) {
             return magicPath.files(prefix, path).forEach(function(file) {
               return filePaths.push(file);

--- a/src/client_asset_manager/client.coffee
+++ b/src/client_asset_manager/client.coffee
@@ -78,7 +78,7 @@ exports.init = (root, codeWrappers, templateEngine) ->
           includes = includes.concat(@headers(packAssets))
 
           # Add any Client-side Templates
-          paths.tmpl != false && files = magicPath.files(pathlib.join(root, templateDir), paths.tmpl)
+          paths.tmpl != false && files = magicPath.files(pathlib.join(root, templateDir).replace(/\\/g, '/'), paths.tmpl) # replace '\' with '/' to support Windows
           if files && files.length > 0
             templateEngine.generate root, templateDir, files, formatters, (templateHTML) ->
               includes.push templateHTML
@@ -115,7 +115,7 @@ exports.init = (root, codeWrappers, templateEngine) ->
         # Expand any dirs into real files
         if paths && paths.length > 0
           filePaths = []
-          prefix = pathlib.join(root, dir)
+          prefix = pathlib.join(root, dir).replace(/\\/g, '/') # replace '\' with '/' to support Windows
           paths.forEach (path) ->
             magicPath.files(prefix, path).forEach (file) -> filePaths.push(file)
           processFiles()


### PR DESCRIPTION
To work on Windows, the current head needs the substitution of '\' to '/' in a couple more places. With this change, the chat demo works in both development and production modes.
