### PR TITLE
choose the collect formatter for template files

### DIFF
--- a/lib/client_asset_manager/template_engine.js
+++ b/lib/client_asset_manager/template_engine.js
@@ -1,4 +1,5 @@
-var echoFormatter, fs, pathlib, tlib;
+var echoFormatter, fs, pathlib, tlib,
+  __indexOf = Array.prototype.indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
 
 fs = require('fs');
 
@@ -47,7 +48,17 @@ exports.init = function(root) {
         var extension, formatter, fullPath;
         fullPath = pathlib.join(root, templateDir, path);
         extension = pathlib.extname(path) || '';
-        formatter = formatters[extension.substring(1)] || echoFormatter;
+        formatter = ((function() {
+          var _i, _len, _ref, _results;
+          _results = [];
+          for (_i = 0, _len = formatters.length; _i < _len; _i++) {
+            formatter = formatters[_i];
+            if (_ref = extension.substring(1), __indexOf.call(formatter.extensions, _ref) >= 0) {
+              _results.push(formatter);
+            }
+          }
+          return _results;
+        })())[0] || echoFormatter;
         return formatter.compile(fullPath, {}, function(output) {
           var engine;
           engine = tlib.selectEngine(templateEngines, path) || defaultEngine;

--- a/src/client_asset_manager/template_engine.coffee
+++ b/src/client_asset_manager/template_engine.coffee
@@ -50,7 +50,7 @@ exports.init = (root) ->
       extension = pathlib.extname(path) || ''
 
       # default to the echo formatter
-      formatter = formatters[extension.substring 1] || echoFormatter
+      formatter = (formatter for formatter in formatters when extension.substring(1) in formatter.extensions)[0] || echoFormatter
 
       formatter.compile fullPath, {}, (output) ->
         engine = tlib.selectEngine(templateEngines, path) || defaultEngine


### PR DESCRIPTION
previously probably

formatters = {'.jade' : formatter_object, 'html', formatter_object}

but now

formatters = [ { name: 'Jade',
    extensions: [ 'jade' ],
    assetType: 'html',
    contentType: 'text/html',
    compile: [Function] },
  { extensions: [ 'html' ],
    assetType: 'html',
    contentType: 'text/html',
    compile: [Function] } ]
