### PR TITLE
gzippo.staticGzip middleware is used instead of connect.static to serve static files

### DIFF
--- a/src/http/index.coffee
+++ b/src/http/index.coffee
@@ -7,6 +7,7 @@ fs = require('fs')
 pathlib = require('path')
 fileUtils = require('../utils/file')
 connect = require('connect')
+gzippo = require('gzippo')
 
 router = new (require('./router').Router)
 
@@ -53,7 +54,7 @@ exports.init = (root) ->
     # Finally ensure static asset serving is last
     app
     .use(eventMiddleware)
-    .use(connect.static(staticPath))
+    .use(gzippo.staticGzip(staticPath))
 
     # Prevent sessions from loading on requests for static assets
     # Not working yet as this functionality not present in Connect 2 yet as far as I can tell


### PR DESCRIPTION
It's a patch implementing #165. Note that dependency on `gzippo` should also be added to `package.json`.

Apache Benchmark (ab) tool shows the same performance as before if `Accept-encoding: gzip` is not sent by HTTP user agent, and 3 times better improved performance if `Accept-encoding: gzip`. On my system with large 500KB asset.js it's 500 requests per second for connect.static and 1500 requests per second for gzippo.staticGzip. I used the following command line to benchmark:

``` sh
ab -n 10000 -c 20  -H 'Accept-encoding: gzip' http://localhost:3000/assets/main/1331635163016.js
```
