### PR TITLE
In Windows, fix path for wrapped assets when a subfolder is specified

### DIFF
--- a/lib/client/asset.js
+++ b/lib/client/asset.js
@@ -56,7 +56,7 @@ loadFile = function(root, dir, fileName, type, options, cb) {
   if (formatter.assetType !== type) {
     throw new Error("Unable to render " + (type.toUpperCase()) + " '" + paths.view + "'. " + formatter.name + " is not a " + (type.toUpperCase()) + " formatter");
   }
-  return formatter.compile(path, options, cb);
+  return formatter.compile(path.replace(/\\/g, '/'), options, cb);
 };
 
 formatKb = function(size) {

--- a/src/client/asset.coffee
+++ b/src/client/asset.coffee
@@ -46,7 +46,7 @@ loadFile = (root, dir, fileName, type, options, cb) ->
   throw new Error("Invalid path. Request for #{path} must not live outside #{dir}") if path.substr(0, dir.length) != dir
   throw new Error("Unsupported file extension '.#{extension}' when we were expecting some type of #{type.toUpperCase()} file. Please provide a formatter for #{path.substring(root.length)} or move it to /client/static") unless formatter
   throw new Error("Unable to render #{type.toUpperCase()} '#{paths.view}'. #{formatter.name} is not a #{type.toUpperCase()} formatter") unless formatter.assetType == type
-  formatter.compile(path, options, cb)
+  formatter.compile(path.replace(/\\/g, '/'), options, cb) # replace '\' with '/' to support Windows
 
 formatKb = (size) ->
   "#{Math.round(size * 1000) / 1000} KB"


### PR DESCRIPTION
The path passed into the asset wrapper contains "\" separators on Windows. The wrappers split the path on "/", and pass in an empty path to the parser. This is only an issue when a subfolder is specified to a specific asset file, and that file has `@import` statements in it.

An example is bootstrap, which is split up into several files.

``` javascript
ss.client.define('main', {
  css:  ['bootstrap/bootstrap.less', ...],
  ...
});
```

I suspect there is a better solution to support Windows than adding `.replace(/\\/g, '/')` in several places, but for now this does the trick.
