### PR TITLE
Live Reload only reloads once - when using Vim

### DIFF
--- a/lib/client/live_reload.js
+++ b/lib/client/live_reload.js
@@ -47,11 +47,18 @@ module.exports = function(root, options, ss) {
       return fs.watch(dir, detectNewFiles);
     });
     return paths.files.forEach(function(file) {
-      var changeAction, extension;
+      var changeAction, extension, watcher;
       extension = file.split('.')[file.split('.').length - 1];
       changeAction = cssExtensions.indexOf(extension) >= 0 && 'updateCSS' || 'reload';
-      return fs.watch(file, function(event, filename) {
-        return handleFileChange(changeAction);
+      return watcher = fs.watch(file, function(event, filename) {
+        handleFileChange(changeAction);
+        if (event === "rename") {
+          watcher.close();
+          return watch({
+            files: [file],
+            dirs: []
+          });
+        }
       });
     });
   };

--- a/src/client/live_reload.coffee
+++ b/src/client/live_reload.coffee
@@ -40,7 +40,11 @@ module.exports = (root, options, ss) ->
     paths.files.forEach (file) ->
       extension = file.split('.')[file.split('.').length-1]
       changeAction = cssExtensions.indexOf(extension) >= 0 && 'updateCSS' || 'reload'
-      fs.watch file, (event, filename) -> handleFileChange(changeAction)
+      watcher = fs.watch file, (event, filename) ->
+        handleFileChange(changeAction)
+        if event == "rename"
+          watcher.close()
+          watch({files: [file], dirs: []})
 
   detectNewFiles = ->
     pathsNow = assetsToWatch()


### PR DESCRIPTION
Hi,

This fixed Live Reload for me using Vim on Linux.

Note that the patch includes my change to the live_reload.coffee file plus the make generated change to live_reload.js - let me know if you only want the coffeescript file change.
- Symptom: When using an editor (e.g. like Vim) that renames a file
  when saving changes, socketstream Live Reload will stop
  working after the first change reload.
- Change: Check for the "rename" event, close old watch
  and open a new watch for the file.
- Test: Besides testing functionality, run in bash:
  `ls -l /proc/<pid>/fd | grep inotify | wc -l`
  and ensure line count stays the same across multiple
  watch file changes.
  `<pid>` is the process id of the running socketstream node app.
- Based on Trevor Burnhams answer to:
  http://stackoverflow.com/questions/8280915/coffeescript-1-1-3-watch-only-works-once
- OS: Ubuntu 10.04
