### PR TITLE
route matching with query parameters

### DIFF
--- a/src/http/router.coffee
+++ b/src/http/router.coffee
@@ -21,7 +21,12 @@ class exports.Router
     else
       if url == '/'
         return false
-      sr = url.split('/')
+
+      if url.indexOf('?') >= 0
+        sr = url.split('?')
+      else
+        sr = url.split('/')
+
       sr.pop()
       newUrl = sr.join('/')
       newUrl = '/' unless newUrl.length > 0


### PR DESCRIPTION
It would be helpful if the route matching algorithm would ignore trying to match any parameters before popping of url components. That way applications could be arbitrarily parameterized upon start. For / this already worked since it fell back, but for nested apps it did not.

i made a minimal change to split of ?. it is naive but does the job for now.
