### PR TITLE
Make <SocketStream> tag xml compliant

### DIFF
--- a/lib/client/formatters/html.js
+++ b/lib/client/formatters/html.js
@@ -13,6 +13,7 @@ exports.init = function() {
       input = fs.readFileSync(path, 'utf8');
       if (options && options.headers) {
         input = input.replace('<SocketStream>', options.headers);
+        input = input.replace('<SocketStream/>', options.headers);
       }
       return cb(input);
     }

--- a/src/client/formatters/html.coffee
+++ b/src/client/formatters/html.coffee
@@ -13,8 +13,8 @@ exports.init = ->
     input = fs.readFileSync(path, 'utf8')
 
     # If passing optional headers for main view
-	if options && options.headers
-		input = input.replace('<SocketStream>', options.headers)
-		input = input.replace('<SocketStream/>', options.headers)
+    if options && options.headers
+      input = input.replace('<SocketStream>', options.headers)
+      input = input.replace('<SocketStream/>', options.headers)
 
     cb(input)


### PR DESCRIPTION
It's backward compatible, yet I believe the xml version should be the only one to use.
   should go away with 0.4 anyways.
