### PR TITLE
Issue with 3rd party transports

### DIFF
--- a/lib/publish/transport.js
+++ b/lib/publish/transport.js
@@ -12,7 +12,7 @@ module.exports = function() {
       }
       config = cfg;
       return transport = (function() {
-        if (typeof nameOrModule === 'object') {
+        if (typeof nameOrModule === 'function') {
           return nameOrModule;
         } else {
           modPath = "./transports/" + nameOrModule;

--- a/src/publish/transport.coffee
+++ b/src/publish/transport.coffee
@@ -10,7 +10,7 @@ module.exports = () ->
 
   use: (nameOrModule, cfg = {}) ->
     config = cfg
-    transport = if typeof(nameOrModule) == 'object'
+    transport = if typeof(nameOrModule) == 'function'
       nameOrModule
     else
       modPath = "./transports/#{nameOrModule}"


### PR DESCRIPTION
This fixes a bug with 3rd party transports.  You were checking for an object, but it really should be a function in order to be able to do, for example: 

``` javascript
ss.publish.transport.use(require('ss-mubsub'), {db: 'test'});
```

And have the config passed properly into the exports instantiation function.

[ss-mubsub](https://github.com/polidore/ss-mubsub) won't work until this is fixed.
