### PR TITLE
Character encoding should appear earlier in the HTML

### DIFF
--- a/new_project/client/views/app.demo.html
+++ b/new_project/client/views/app.demo.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <SocketStream/>
     <meta charset="utf-8"/>
+    <SocketStream/>
     <title>Welcome</title>
   </head>
   <body>

--- a/new_project/client/views/app.demo.jade
+++ b/new_project/client/views/app.demo.jade
@@ -1,8 +1,8 @@
 !!! 5
 html(lang="en")
   head
-    != SocketStream
     meta(charset="utf-8")
+    != SocketStream
     title Welcome
   body
     #content

--- a/new_project/client/views/app.minimal.html
+++ b/new_project/client/views/app.minimal.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <SocketStream/>
     <meta charset="utf-8"/>
+    <SocketStream/>
     <title>Welcome</title>
   </head>
   <body>

--- a/new_project/client/views/app.minimal.jade
+++ b/new_project/client/views/app.minimal.jade
@@ -1,8 +1,8 @@
 !!! 5
 html(lang="en")
   head
-    != SocketStream
     meta(charset="utf-8")
+    != SocketStream
     title Welcome
   body
     p Welcome to your new realtime app!


### PR DESCRIPTION
Some browsers apparently pre-parse the first 1kB of HTML to try to find the character encoding, before trying to guess what it is. [Relevant section of HTML5 draft spec](http://www.w3.org/TR/html5/parsing.html#determining-the-character-encoding).

In development mode, with a large number of client scripts, the SocketStream header output can be large. This can push the `<meta charset="utf-8">` so it is outside of the first 1kB of the file. Firefox generates this message, which can be seen in FireBug:

> The character encoding declaration of the HTML document was not found when prescanning the first 1024 bytes of the file. When viewed in a differently-configured browser, this page will reload automatically. The encoding declaration needs to be moved to be within the first 1024 bytes of the file.

This would never be an issue in production mode, since the assets are packed, so this is a pretty unimportant change.
