### PR TITLE
A fix for #299

### DIFF
--- a/lib/utils/unique_set.js
+++ b/lib/utils/unique_set.js
@@ -22,6 +22,9 @@ exports.UniqueSet = (function() {
 
   UniqueSet.prototype.remove = function(key, value) {
     var i;
+    if (this.data[key] === void 0) {
+      return;
+    }
     if ((i = this.data[key].indexOf(value)) >= 0) {
       this.data[key].splice(i, 1);
       if (this.data[key].length === 0) {

--- a/src/utils/unique_set.coffee
+++ b/src/utils/unique_set.coffee
@@ -13,6 +13,7 @@ class exports.UniqueSet
       @data[key] = [value]
 
   remove: (key, value) ->
+    return if @data[key] is undefined
     if (i = @data[key].indexOf(value)) >= 0
       @data[key].splice(i, 1)
       delete @data[key] if @data[key].length == 0


### PR DESCRIPTION
I've added a fix to handle the problem mentioned here:

https://github.com/socketstream/socketstream/issues/299

The unique_set#remove function was breaking because the @data object did not contain a [key] property, where @data was {}, and key was user_50ac10ac6df6820832000008 (the channel).

As a result, the call to @data[key] on line 16 was breaking because @data[key] is undefined. I therefore put in a return call to skip the rest of the function, as the @data object does not contain that property.  
