### PR TITLE
RPC actions can now be a constructed object rather than a literal.

### DIFF
--- a/src/request/responders/rpc/request.coffee
+++ b/src/request/responders/rpc/request.coffee
@@ -68,7 +68,7 @@ module.exports = (ss, middleware) ->
       return res(new Error("The '#{req.method}' method in exports.actions must be a function")) unless typeof(method) == 'function'
 
       # Execute action
-      method.apply(method, req.params)
+      method.apply(actions, req.params)
 
     # Add RPC call to bottom of middleware stack
     stack.push(main)


### PR DESCRIPTION
This is lighter from a memory standpoint, especially for large handlers.

Example:

``` JavaScript
function RPC(req,res,ss){
  this.req = req;
  this.res = res;
  this.ss = ss;
}

RPC.prototype.sendMessage = function(message) {
  if (message && message.length > 0) {          // Check for blank messages
    this.ss.publish.all('newMessage', message); // Broadcast the message to everyone
    return this.res(true);                      // Confirm it was sent to the originating client
  } else {
    return this.res(false);
  }
}

exports.actions = function(req, res, ss) {
  req.use('session');
  return new RPC(req,res,ss);
};
```

Something tells me it is actually an oversight :-)
