### PR TITLE
Fix memory leak and possible performance hit

### DIFF
--- a/src/client/serve/ondemand.coffee
+++ b/src/client/serve/ondemand.coffee
@@ -17,12 +17,12 @@ module.exports = (ss, router, options) ->
 
   serve = (processor) ->
     (request, response) ->
-      if options.packAssets && queryCache[request.url]
-        utils.serve.js(queryCache[request.url], response)
+      path = utils.parseUrl(request.url)
+      if options.packAssets && queryCache[path]
+        utils.serve.js(queryCache[path], response)
       else
-        path = utils.parseUrl(request.url)
         processor request, response, path, (output) ->
-          queryCache[request.url] = output
+          queryCache[path] = output
           utils.serve.js(output, response)
 
   # Async Code Loading


### PR DESCRIPTION
Loading code on demand is not hitting the query cache due to an extra parameter which the ajax method appends:

``` javascript
ss.load.code('/test', function() {
    require('/cached.js');
});
```

calls: `/_serve/code?test&_=1359143112452` (ajax cache: false)

This causes the `queryCache` to be filled with output data for every subsequent call (on every client refresh, or new request).

This way the browser keeps fresh while the server is not minifying the content on every subsequent request to single client code.

This reminds me that may be better handling of the pack assets procedure could be:

``` javascript
ss.client.options.packAssets = process.env['SS_PACK'] || false;

// Minimize and pack assets if you type: SS_ENV=production node app.js
if ((process.env.SS_ENV || process.env.NODE_ENV || 'production') === 'production' || ss.client.options.packAssets) {
    ss.client.options.packAssets = true;
    ss.client.packAssets({keepOldFiles: true});
}
```
