### PR TITLE
util/file.js : Change lstatSync to statSync to correctly resolve symlinks

### DIFF
--- a/lib/utils/file.js
+++ b/lib/utils/file.js
@@ -4,8 +4,8 @@ var fs = require('fs'),
 // Read the contents of a dir. Adapted from https://gist.github.com/825583
 exports.readDirSync = function(start) { 
   try {
-    // Use lstat to resolve symlink if we are passed a symlink
-    var stat = fs.lstatSync(start);
+    // Use stat to resolve symlink if we are passed a symlink
+    var stat = fs.statSync(start);
     var found = {dirs: [], files: []}, total = 0, processed = 0;
     function isHidden(path){ return path.match(/(^_|^\.|~$)/); }
     function isDir(abspath) {


### PR DESCRIPTION
Fixes #384

Change lstatSync to statSync to correctly resolve symlinks under
client/static/.
