### PR TITLE
Added 'Content-Type': 'text/html, utf-8' on response header defenition

### DIFF
--- a/lib/client/http.js
+++ b/lib/client/http.js
@@ -35,7 +35,7 @@ module.exports = function(ss, clients, options) {
       }
       self.writeHead(code, {
         'Content-Length': Buffer.byteLength(html),
-        'Content-Type': 'text/html, utf-8'
+        'Content-Type': 'text/html; charset=UTF-8'
       });
       return self.end(html);
     };


### PR DESCRIPTION
Hi guys,

Added charset definition  for header's `Content-Type`

As you know, specifying a character set early for your HTML documents allows the browser to begin executing scripts immediately.

Form here https://developers.google.com/speed/docs/best-practices/rendering#SpecifyCharsetEarly :

> Microsoft notes: "we continue to strongly recommend that web developers specify the CHARSET in the HTTP Content-Type response header, as this ensures that the performance benefit of the Lookahead Downloader is realized".
