### PR TITLE
Added support for GZIP compression for main HTML files

### DIFF
--- a/lib/client/http.js
+++ b/lib/client/http.js
@@ -33,11 +33,15 @@ module.exports = function(ss, clients, options) {
       if (code == null) {
         code = 200;
       }
-      self.writeHead(code, {
-        'Content-Length': Buffer.byteLength(html),
-        'Content-Type': 'text/html'
-      });
-      return self.end(html);
+      /*
+        self.writeHead(code, header) removed to allow connect.compress() perform static HTML files compression.
+        Before it was work only for static asserts because of response header overwriting.
+        Instead we do set response status and header with two separate methods  self.statusCode and self.setHeader(name, value);
+       */
+      self.statusCode = code;
+      self.setHeader('Content-Length', Buffer.byteLength(html));
+      self.setHeader('Content-Type', 'text/html');
+      self.end(html);
     };
     try {
       client = typeof name === 'string' && clients[name];

--- a/lib/http/index.js
+++ b/lib/http/index.js
@@ -68,6 +68,9 @@ module.exports = function(root) {
       staticPath = pathlib.join(root, staticPath);
       loadStaticDirs(staticPath);
 
+      /* connect.compress() should be added to middleware stack on highest possible position */
+      app.use(connect.compress());
+
       // Append SocketStream middleware upon server load      
       app.use(connect.cookieParser('SocketStream')).use(connect.favicon(staticPath + '/favicon.ico')).use(connect.session({
         cookie: {
@@ -85,7 +88,7 @@ module.exports = function(root) {
       });
 
       // Finally ensure static asset serving is last      
-      app.use(eventMiddleware).use(connect.compress()).use(connect["static"](staticPath, settings["static"]));
+      app.use(eventMiddleware).use(connect["static"](staticPath, settings["static"]));
       return app;
     },
 


### PR DESCRIPTION
Hi everyone,

I have spent some time to finally come up with the solution for gzip support for main HTML files. Related issue https://github.com/socketstream/socketstream/pull/376

Works only for packed files, which does make cense.

I tested with default SocketStream demo app (http + connect) and with more advanced with [Express.js](https://github.com/visionmedia/express) on the top.

Results:

```
Date                Wed, 09 Oct 2013 19:59:55 GMT
Content-Encoding    gzip
Transfer-Encoding   chunked
Connection          keep-alive
Vary                Accept-Encoding
Content-Type        text/html
```

and with Express

```
Date                Wed, 09 Oct 2013 20:00:14 GMT
Content-Encoding    gzip
Transfer-Encoding   chunked
Connection          keep-alive
X-Powered-By        Express
Vary                Accept-Encoding
Content-Type        text/html
```
