### PR TITLE
RPC Actions can now be an object created with `new` rather than a literal.

### DIFF
--- a/lib/request/responders/rpc/request.js
+++ b/lib/request/responders/rpc/request.js
@@ -87,7 +87,7 @@ module.exports = function(ss, middleware) {
       }
 
       // Execute action      
-      return method.apply(method, req.params);
+      return method.apply(actions, req.params);
     };
 
     // Add RPC call to bottom of middleware stack    


### PR DESCRIPTION
This is a revival of #327, now that Paul is at the helm I hope it can be revisited.

This tiny patch allows to use objects created with `new` as RPC handlers, rather than object literals with closures. It removes pressure from the allocator/garbage collector, since otherwise, closures have to be created for each requests, most of which are not used anyway. 

The resulting code is a bit uglier but much more efficient, especially for large RPC APIs.

Example (revisiting the "new_project" sample):

``` JavaScript
function RPC(req,res,ss){
  this.req = req;
  this.res = res;
  this.ss = ss;
}

RPC.prototype.sendMessage = function(message) {
  if (message && message.length > 0) {          // Check for blank messages
    this.ss.publish.all('newMessage', message); // Broadcast the message to everyone
    return this.res(true);                      // Confirm it was sent to the originating client
  } else {
    return this.res(false);
  }
}

exports.actions = function(req, res, ss) {
  req.use('session');
  return new RPC(req,res,ss);
};
```

The old method can still be used for all practical use cases.

The patch may theoretically break code that relies on the fact that, without the patch, `this` in a handler is the handler itself. I can't see anyone sane rely on that.
