### PR TITLE
Fixed merge order for jshint tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,14 +30,17 @@ module.exports = function(grunt) {
 
                    http://www.jshint.com/docs/options/#devel
                  */
-                options: grunt.util._.merge({
-                    ignores: [
-                        'lib/client/system/libs/*',
-                        'lib/client/system/modules/*',
-                        'lib/websocket/transports/engineio/*',
-                        'test/fixtures/project/client/code/libs/*'
-                    ]
-                }, grunt.file.readJSON('.jshintrc')),
+                options: grunt.util._.merge(
+                    grunt.file.readJSON('.jshintrc'),
+                    {
+                        ignores: [
+                            'lib/client/system/libs/*',
+                            'lib/client/system/modules/*',
+                            'lib/websocket/transports/engineio/*',
+                            'test/fixtures/project/client/code/libs/*'
+                        ]
+                    }
+                ),
                 files: {
                     src: [
                         'Gruntfile.js',
@@ -48,14 +51,17 @@ module.exports = function(grunt) {
                 }
             },
             client: {
-                options: grunt.util._.merge({
-                    browser: true,
-                    node   : false,
-                    ignores: [
-                        'lib/client/system/libs/*',
-                        'lib/client/system/index.js'
-                    ]
-                }, grunt.file.readJSON('.jshintrc')),
+                options: grunt.util._.merge(
+                    grunt.file.readJSON('.jshintrc'),
+                    {
+                        browser: true,
+                        node   : false,
+                        ignores: [
+                            'lib/client/system/libs/*',
+                            'lib/client/system/index.js'
+                        ]
+                    }
+                ),
                 files: {
                     src: [
                         'lib/client/system/**/*.js'


### PR DESCRIPTION
Custom options should override options from .jshintrc file.

Before options `node=false, browser=true` have been missed for client file linting.
