### PR TITLE
#286 Static file error with 404

### DIFF
--- a/lib/http/router.js
+++ b/lib/http/router.js
@@ -2,9 +2,11 @@
 // -----------
 // Right now the router is simply an EventEmitter. This may change in the future
 
-var EventEmitter2;
+var EventEmitter2,
+    path;
 
 EventEmitter2 = require('eventemitter2').EventEmitter2;
+path = require('path');
 
 exports.Router = (function() {
 


### PR DESCRIPTION
#286 I added a simple check for file extensions using the `path` module.  Originally a url like `content/uploads/345.jpg`would result in the following event fires from router

``` bash
content/uploads/345.jpg
content/uploads
content/
```

ultimately returning the `client.js` to the browser.

With my adjustment

now the execution stack ends with just

``` bash
content/uploads/345.jpg
```

and propagates to the static-middleware which returns a 404 

:warning: this might be a naive solution, but it seems to work.
