### PR TITLE
Accept node env as environment variable

### DIFF
--- a/lib/socketstream.js
+++ b/lib/socketstream.js
@@ -2,6 +2,10 @@
 // ----------------
 'use strict';
 
+// console.log('CHECK');
+// console.log(process.env);
+// console.log('/CHECK');
+
 require('colors');
 
 var EventEmitter2 = require('eventemitter2').EventEmitter2;
@@ -14,11 +18,13 @@ var root = exports.root = process.cwd().replace(/\\/g, '/'); // replace '\' with
 
 // Warn if attempting to start without a cwd (e.g. through upstart script)
 if (root === '/') {
-  throw new Error("You must change into the project directory before starting your SocketStream app");
+  throw new Error('You must change into the project directory before starting your SocketStream app');
 }
 
 // Set environment
-var env = exports.env = (process.env['SS_ENV'] || 'development').toLowerCase();
+// console.log("SS ENV IS ", process.env['SS_ENV']);
+
+var env = exports.env = (process.env['NODE_ENV'] || process.env['SS_ENV'] || 'development').toLowerCase();
 
 // Session & Session Store
 var session = exports.session = require('./session');

--- a/test/helpers/uncache.js
+++ b/test/helpers/uncache.js
@@ -1,0 +1,59 @@
+'use strict';
+
+
+
+// These are helper methods extracted from here: 
+// http://stackoverflow.com/questions/9210542/node-js-require-cache-possible-to-invalidate
+
+
+
+/**
+ * Removes a module from the cache
+ * @param  {String} moduleName the path of the module
+ * @return {Void}
+ */
+require.uncache = function (moduleName) {
+    // Run over the cache looking for the files
+    // loaded by the specified module name
+    require.searchCache(moduleName, function (mod) {
+        delete require.cache[mod.id];
+    });
+};
+
+
+
+/**
+ * Runs over the cache to search for all the cached
+ * files
+ * @param  {String}     moduleName  the path of the module
+ * @param  {Function}   next        callback
+ * @return {Void}
+ */
+require.searchCache = function (moduleName, callback) {
+    // Resolve the module identified by the specified name
+    var mod = require.resolve(moduleName);
+
+    // Check if the module has been resolved and found within
+    // the cache
+    if (mod && ((mod = require.cache[mod]) !== undefined)) {
+        // Recursively go over the results
+        (function run(mod) {
+            // Go over each of the module's children and
+            // run over it
+            mod.children.forEach(function (child) {
+                run(child);
+            });
+
+            // Call the specified callback providing the
+            // found module
+            callback(mod);
+        })(mod);
+    }
+};
+
+
+
+/**
+ * Expose the Public API
+ */
+module.exports = require;

--- a/test/unit/socketstream.test.js
+++ b/test/unit/socketstream.test.js
@@ -4,7 +4,8 @@
 
 // Dependencies
 
-var ac            = require('../helpers/assertionCounter');
+var ac                    = require('../helpers/assertionCounter'),
+    require               = require('../helpers/uncache');
 
 
 
@@ -13,20 +14,19 @@ describe('lib/socketstream', function () {
 
 
     beforeEach(function (done) {
-
-        process.env.NODE_ENV = undefined;
+        require.uncache('../../lib/socketstream.js');
+        delete process.env.SS_ENV;
+        delete process.env.NODE_ENV;
         ac.reset();
         done();
-
     });
 
 
 
     afterEach(function (done) {
-
-        process.env.NODE_ENV = 'test';
+        delete process.env.SS_ENV;
+        process.env.NODE_ENV  = 'test';
         done();
-
     });
 
 
@@ -35,18 +35,30 @@ describe('lib/socketstream', function () {
 
 
 
-        it('should inherit the Node environment variable from NODE_ENV, if passed');
+        it('should inherit the Node environment variable from NODE_ENV, if passed', function (done) {
+            ac.expect(1);
+            process.env.NODE_ENV = 'cucumber';
+            var ss = require('../../lib/socketstream.js');
+            ss.env.should.equal('cucumber').andCheck();
+            ac.check(done);
+        });
 
 
 
-        it('should inherit the Node environment variable from SS_ENV, if passed');
+        it('should inherit the Node environment variable from SS_ENV, if passed', function (done) {
+            ac.expect(1);
+            process.env.SS_ENV = 'staging';
+            var ss = require('../../lib/socketstream.js');
+            ss.env.should.equal('staging').andCheck();
+            ac.check(done);
+        });
 
 
 
         it('should default to development, if neither NODE_ENV or SS_ENV are passed', function (done) {
             ac.expect(1);
-            var socketstream = require('../../lib/socketstream.js');
-            socketstream.env.should.equal('development').andCheck();
+            var ss = require('../../lib/socketstream.js');
+            ss.env.should.equal('development').andCheck();
             ac.check(done);
         });
 


### PR DESCRIPTION
In order to pass the desired environment to your SocketStream app, you have to pass it this way:

```
SS_ENV=production npm start
```

Now, in fitting with Node's conventions, you can also pass it like this:

```
NODE_ENV=production npm start
```
