### PR TITLE
fix(http): Allow setting your own cookie parser secret

### DIFF
--- a/lib/http/index.js
+++ b/lib/http/index.js
@@ -168,7 +168,9 @@ module.exports = function(root) {
       app.use(connect.compress());
 
       /* Append SocketStream middleware upon server load */
-      app.use(connect.cookieParser('SocketStream')).use(connect.favicon(staticPath + '/favicon.ico')).use(connect.session({
+      app.use(connect.cookieParser(sessionOptions.secret || 'SocketStream'));
+
+      app.use(connect.favicon(staticPath + '/favicon.ico')).use(connect.session({
         cookie: {
           path: '/',
           httpOnly: false,

--- a/src/docs/tutorials/en/sessions.ngdoc
+++ b/src/docs/tutorials/en/sessions.ngdoc
@@ -88,3 +88,11 @@ By default sessions will expire within 30 days, unless the session is terminated
     ss.session.options.maxAge = 8640000;  // one day in milliseconds
 </pre>
 
+### Setting a Secret
+By default the cookie parser will use `'SocketStream'` as its secret. You
+*should* set your own secret in production:
+
+<pre>
+    // in app.js
+    ss.session.options.secret = crypto.randomBytes(32).toString();
+</pre>


### PR DESCRIPTION
By doing: `ss.session.options.secret = 'foo'`.

This pull request doesn't rebuild docs, let me know if I should also include that!
