### PR TITLE
fixed the deprecation errors by adding relevant options

### DIFF
--- a/lib/http/index.js
+++ b/lib/http/index.js
@@ -187,7 +187,9 @@ module.exports = function(root) {
             secure: settings.secure
           },
           store: sessionStore,
-          secret: secret
+          secret: secret,
+          resave: false,
+          saveUninitialized: true
         }));
       }
 


### PR DESCRIPTION
There were some annoying express-session deprecated options error warnings on every run-- now removed.  