### PR TITLE
feat(test): added a task for testing transporters 'test-socketstream'

### DIFF
--- a/lib/socketstream.js
+++ b/lib/socketstream.js
@@ -25,7 +25,6 @@ if (root === '/') {
 }
 
 // Set environment
-// console.log("SS ENV IS ", process.env['SS_ENV']);
 
 var env = exports.env = (process.env['NODE_ENV'] || process.env['SS_ENV'] || 'development').toLowerCase();
 
@@ -148,8 +147,7 @@ api.client = {send: client.assets.send, dirs: client.dirs};
 api.server = {};
 
 function getServer() {
-  if (api.server.responders == null) {
-    api.server.responders = responders.load();
+  if (api.server.eventTransport == null) {
     api.server.eventTransport = publish.transport.load();
 
     // Extend the internal API with a publish object you can call from your own server-side code
@@ -159,7 +157,7 @@ function getServer() {
 }
 
 // Incoming Request Responders
-var responders = exports.responders = require('./request/index')(api);
+exports.responders = require('./request/index')(api);
 
 // Websocket Layer (transport, message responders, transmit incoming events)
 var ws = exports.ws = require('./websocket/index')(api);
@@ -173,10 +171,13 @@ exports.start = function() {
   return serverInstance || (serverInstance = start.apply(null,arguments));
 };
 
+// API for implementing your own start-server task
 exports.stream = api.stream = stream;
 
 function stream(httpServer) {
-  api.log.info('Starting SocketStream %s in %s mode...'.green, version, env);
+  if (httpServer) {
+    api.log.info('Starting SocketStream %s in %s mode...'.green, version, env);
+  }
   var server = getServer();
   server.httpServer = httpServer;
 
@@ -193,6 +194,9 @@ function load() {
 
     // Load Client Asset Manager
     client.load();
+
+    // Load internal and project responders
+    api.server.responders = exports.responders.load();
   }
 }
 
@@ -203,6 +207,7 @@ function unload() {
   client.unload();
   client.assets.unload();
   http.unload();
+  api.server.responders = undefined;
   ws.unload();
 }
 

--- a/lib/tasks/defaults.js
+++ b/lib/tasks/defaults.js
@@ -25,6 +25,28 @@ module.exports = function(ss, router, options, orchestrator) {
       ss.load();
     });
 
+    ss.defaultTask('test-socketstream', ['load-api'], function() {
+      ss.stream();
+      var sessionID = ss.session.create();
+
+      // jshint loopfunc:true
+      for (var id in ss.server.responders) {
+        if (ss.server.responders.hasOwnProperty(id)) {
+          var responder = ss.server.responders[id];
+
+          if (responder.name && responder.interfaces.internal) {
+            var fn = function(){
+              var args = Array.prototype.slice.call(arguments),
+                  cb = args.pop();
+
+              return responder.interfaces.internal(args, {sessionId: sessionID, transport: 'test'}, function(err, params){ cb(params); });
+            };
+            ss.add(responder.name, fn); // interesting, potential or hack?
+          }
+        }
+      }
+    });
+
     // if the server was passed in ss.start(httpServer) one shouldn't be started
     ss.defaultTask('load-socketstream', (ss.server.httpServer == null)? ['start-server','load-api']:['load-api']);
 


### PR DESCRIPTION
This should allow you to add a test for your RPC code.

    describe('Demo', function() {
      beforeEach(function(done) {
        ss = require("socketstream").start('test-socketstream',done);
      });

      describe('sendMessage', function() {

        it('should publish messages received', function(done) {
          var text = 'Hello World!';
          ss.rpc('demo.sendMessage', text, function(res) {
            expect(res).to.equal([true]);
            //TODO published expectations
            // expect(..).to.equal({ status:'success', content:text});
          })
        });
      });
    });
