### PR TITLE
Fix Issue https://github.com/socketstream/socketstream/issues/609

### DIFF
--- a/lib/socketstream.js
+++ b/lib/socketstream.js
@@ -224,14 +224,14 @@ function start() {
 
   var plan = tasks.plan(arguments);
 
+  tasks.defaults(plan);
+
+  tasks.start(plan.targets,plan.callback);
+
   // Hook in streaming if called with HTTP server
   if (plan.httpServer) {
     stream(plan.httpServer);
   }
-
-  tasks.defaults();
-
-  tasks.start(plan.targets,plan.callback);
 
   if (!exitRegistered) {
     process.on('exit', api.unload);

--- a/lib/tasks/defaults.js
+++ b/lib/tasks/defaults.js
@@ -11,7 +11,7 @@ var http = require('http'),
 
 module.exports = function(ss, router, options, orchestrator) {
 
-  return function() {
+  return function(plan) {
 
     ss.defaultTask('start-server',function(done) {
       var server = http.Server(ss.http.middleware);
@@ -48,7 +48,7 @@ module.exports = function(ss, router, options, orchestrator) {
     });
 
     // if the server was passed in ss.start(httpServer) one shouldn't be started
-    ss.defaultTask('load-socketstream', (ss.server.httpServer == null)? ['start-server','load-api']:['load-api']);
+    ss.defaultTask('load-socketstream', (plan.httpServer == null)? ['start-server','load-api']:['load-api']);
 
     // task: ondemand
     // Listen out for requests to async load new assets


### PR DESCRIPTION
Call stream(plan.httpServer); after running tasks, such that responders are defined when the WebSocket layer is loaded. Pass the plan as an argument to tasks.defaults(plan); such that the decision to include the start-server task in the load-socketstream task can be based on plan.httpServer instead of ss.server.httpServer.